### PR TITLE
WIP: Support interval referential values

### DIFF
--- a/brb/brb.py
+++ b/brb/brb.py
@@ -192,20 +192,14 @@ class RuleBaseModel():
 
     Attributes:
         U: Antecendent attributes' names.
-        A: Referential values for each antecedent.
         D: Consequent referential values.
         F: ?
         rules: List of rules.
     """
-    def __init__(self, U: List[str], A: Dict[str, List[Any]], D: List[Any],
-                 F=None):
+    def __init__(self, U: List[str], D: List[Any], F=None):
         # no repeated elements for U
         assert len(U) == len(set(U))
         self.U = U
-
-        # referential values for all antecedent attributes must be provided
-        assert set(U) == set(A.keys())
-        self.A = A
 
         self.D = D
         self.F = F
@@ -220,11 +214,6 @@ class RuleBaseModel():
         """
         # all reference values must be related to an attribute
         assert set(new_rule.A_values.keys()).issubset(set(self.U))
-
-        # the reference values that activate the rule must be a valid
-        # referential value in the self
-        for U_i, A_i in new_rule.A_values.items():
-            assert A_i in self.A[U_i]
 
         # TODO: handle NaN values
 
@@ -256,12 +245,6 @@ class RuleBaseModel():
 
         # every rule must comply to the amount of antecedent attributes
         assert A_ks.shape[1] == len(self.U)
-
-        # the values in the matrix must comply to the referential values in the
-        # model
-        for A_i, A_ref in zip(A_ks.T, self.A.values()):
-            A_i = A_i[~pd.isna(A_i.tolist())]  # drops nan values
-            assert np.isin(A_i, A_ref).all()
 
         # same is true for the consequents
         assert np.isin(betas, self.D).all()

--- a/test.py
+++ b/test.py
@@ -5,9 +5,8 @@ from brb.brb import RuleBaseModel, Rule, AttributeInput
 if __name__ == "__main__":
     # setup for simple tests
     U = ['Antecedent']
-    A = {'Antecedent': ['good', 'bad']}
     D = ['good', 'bad']
-    model = RuleBaseModel(U=U, A=A, D=D, F=None)
+    model = RuleBaseModel(U=U, D=D, F=None)
 
     good_rule = Rule(
         A_values={'Antecedent':'good'},
@@ -165,10 +164,6 @@ if __name__ == "__main__":
     # matrix input
     model = RuleBaseModel(
         U=['A_1', 'A_2'],
-        A={
-            'A_1': ['high', 'low'],
-            'A_2': ['large', 'medium', 'small']
-        },
         D=['RS', 'GP']
     )
 


### PR DESCRIPTION
The need for interval-like referential values for numerical attributes is great.

The idea for making this available is to drop the need to comply with the model referential values, so each `Rule` instance will define the referential values on their own. Then, for categorical values, matching degree will be the certainty of the input on the referential value.

For numerical antecedents, the matching degree will be the amount of the input which is covered by the referential values. This will imply in the addition of interval geometry for continuous (real) numerical values and set operations for discrete (integer) ones.